### PR TITLE
[Phase 1] k6 부하 테스트 스크립트 및 결과 추가 (#7)

### DIFF
--- a/tests/example.spec.js
+++ b/tests/example.spec.js
@@ -1,0 +1,19 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});

--- a/tests/load/config.js
+++ b/tests/load/config.js
@@ -1,0 +1,42 @@
+/**
+ * k6 부하테스트 공통 설정
+ * - BASE_URL, WS_URL 등 환경 설정을 중앙에서 관리합니다.
+ */
+
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+export const API_URL = `${BASE_URL}/api`;
+export const WS_URL = __ENV.WS_URL || 'ws://localhost:8080/ws-stomp';
+
+// 공통 임계값 (성능 기준)
+export const THRESHOLDS = {
+  // HTTP 요청 실패율 1% 미만
+  http_req_failed: ['rate<0.01'],
+  // 95퍼센타일 응답시간 500ms 미만
+  http_req_duration: ['p(95)<500'],
+  // WebSocket 연결 실패율 1% 미만
+  ws_connecting: ['p(95)<1000'],
+};
+
+// 단계별 부하 프로파일 (공통)
+export const RAMP_UP_STAGES = [
+  { duration: '30s', target: 10 },   // 30초 동안 10명까지 증가
+  { duration: '1m',  target: 50 },   // 1분 동안 50명 유지
+  { duration: '30s', target: 100 },  // 30초 동안 100명까지 증가
+  { duration: '2m',  target: 100 },  // 2분 동안 100명 유지 (피크)
+  { duration: '30s', target: 0 },    // 30초 동안 0명으로 감소
+];
+
+// 가벼운 스모크 테스트용 프로파일
+export const SMOKE_STAGES = [
+  { duration: '30s', target: 5 },
+  { duration: '1m',  target: 5 },
+  { duration: '10s', target: 0 },
+];
+
+// 스파이크 테스트용 프로파일
+export const SPIKE_STAGES = [
+  { duration: '10s', target: 10 },
+  { duration: '10s', target: 200 },  // 급격한 부하 증가
+  { duration: '1m',  target: 200 },
+  { duration: '10s', target: 0 },
+];

--- a/tests/load/rest-api.js
+++ b/tests/load/rest-api.js
@@ -1,0 +1,175 @@
+/**
+ * REST API 부하테스트 (k6)
+ *
+ * 테스트 시나리오:
+ *   1. 사용자 생성 (POST /api/users)
+ *   2. 채팅방 목록 조회 (GET /api/chat-rooms?userId=)
+ *   3. 채팅방 생성 (POST /api/chat-rooms)
+ *   4. 채팅방 입장 (POST /api/chat-rooms/{id}/join?userId=)
+ *   5. 메시지 이력 조회 (GET /api/messages/chatroom/{id})
+ *   6. 채팅방 퇴장 (POST /api/chat-rooms/{id}/leave?userId=)
+ *
+ * 실행:
+ *   k6 run tests/load/rest-api.js
+ *   k6 run --env BASE_URL=http://your-server:8080 tests/load/rest-api.js
+ */
+
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { API_URL, THRESHOLDS, RAMP_UP_STAGES } from './config.js';
+
+// 커스텀 메트릭
+const userCreateErrors = new Counter('user_create_errors');
+const roomCreateErrors = new Counter('room_create_errors');
+const joinRoomErrors   = new Counter('join_room_errors');
+const msgHistoryErrors = new Counter('msg_history_errors');
+const apiSuccessRate   = new Rate('api_success_rate');
+const roomJoinDuration = new Trend('room_join_duration', true);
+
+// k6 옵션
+export const options = {
+  stages: RAMP_UP_STAGES,
+  thresholds: {
+    ...THRESHOLDS,
+    user_create_errors:  ['count<10'],
+    room_create_errors:  ['count<10'],
+    join_room_errors:    ['count<20'],
+    api_success_rate:    ['rate>0.99'],
+    room_join_duration:  ['p(95)<800'],
+  },
+};
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export default function () {
+  const vu   = __VU;
+  const iter = __ITER;
+
+  // ─────────────────────────────────────────
+  // STEP 1: 사용자 생성
+  // ─────────────────────────────────────────
+  let userId;
+  group('사용자 생성', () => {
+    const res = http.post(
+      `${API_URL}/users`,
+      { nickname: `load_user_${vu}_${iter}` },
+    );
+
+    const ok = check(res, {
+      '사용자 생성 2xx': (r) => r.status >= 200 && r.status < 300,
+      '사용자 ID 존재': (r) => {
+        try { return r.json().id != null; } catch (_) { return false; }
+      },
+    });
+
+    apiSuccessRate.add(ok);
+    if (!ok) { userCreateErrors.add(1); return; }
+    userId = res.json().id;
+  });
+
+  if (!userId) { sleep(1); return; }
+
+  // ─────────────────────────────────────────
+  // STEP 2: 채팅방 목록 조회
+  // ─────────────────────────────────────────
+  group('채팅방 목록 조회', () => {
+    const res = http.get(`${API_URL}/chat-rooms?userId=${userId}`);
+
+    const ok = check(res, {
+      '채팅방 목록 200': (r) => r.status === 200,
+      '배열 형식 반환':  (r) => {
+        try { return Array.isArray(r.json()); } catch (_) { return false; }
+      },
+    });
+    apiSuccessRate.add(ok);
+  });
+
+  // ─────────────────────────────────────────
+  // STEP 3: 채팅방 생성
+  // ─────────────────────────────────────────
+  let roomId;
+  group('채팅방 생성', () => {
+    const res = http.post(
+      `${API_URL}/chat-rooms`,
+      { name: `테스트방_${vu}_${iter}`, creatorId: userId },
+    );
+
+    const ok = check(res, {
+      '채팅방 생성 2xx': (r) => r.status >= 200 && r.status < 300,
+      '방 ID 존재': (r) => {
+        try { return r.json().id != null; } catch (_) { return false; }
+      },
+    });
+
+    apiSuccessRate.add(ok);
+    if (!ok) { roomCreateErrors.add(1); return; }
+    roomId = res.json().id;
+  });
+
+  if (!roomId) { sleep(1); return; }
+
+  // ─────────────────────────────────────────
+  // STEP 4: 채팅방 입장 (Query Param)
+  // ─────────────────────────────────────────
+  group('채팅방 입장', () => {
+    const start = Date.now();
+    const res = http.post(
+      `${API_URL}/chat-rooms/${roomId}/join?userId=${userId}`,
+      null,
+      { headers: JSON_HEADERS },
+    );
+    roomJoinDuration.add(Date.now() - start);
+
+    const ok = check(res, {
+      '채팅방 입장 200': (r) => r.status === 200,
+      '방 ID 반환':      (r) => {
+        try { return r.json().id != null; } catch (_) { return false; }
+      },
+    });
+
+    apiSuccessRate.add(ok);
+    if (!ok) joinRoomErrors.add(1);
+  });
+
+  // ─────────────────────────────────────────
+  // STEP 5: 메시지 이력 조회
+  // ─────────────────────────────────────────
+  group('메시지 이력 조회', () => {
+    const res = http.get(`${API_URL}/messages/chatroom/${roomId}`);
+
+    const ok = check(res, {
+      '메시지 이력 200': (r) => r.status === 200,
+      '배열 형식 반환':  (r) => {
+        try { return Array.isArray(r.json()); } catch (_) { return false; }
+      },
+    });
+
+    apiSuccessRate.add(ok);
+    if (!ok) msgHistoryErrors.add(1);
+  });
+
+  // ─────────────────────────────────────────
+  // STEP 6: 채팅방 퇴장 (POST, Query Param)
+  // ─────────────────────────────────────────
+  group('채팅방 퇴장', () => {
+    const res = http.post(
+      `${API_URL}/chat-rooms/${roomId}/leave?userId=${userId}`,
+      null,
+      { headers: JSON_HEADERS },
+    );
+
+    const ok = check(res, {
+      '채팅방 퇴장 204': (r) => r.status === 204,
+    });
+    apiSuccessRate.add(ok);
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    'tests/load/results/rest-api-summary.json': JSON.stringify(data, null, 2),
+  };
+}

--- a/tests/load/results/stress-multi-room-8rooms-summary.json
+++ b/tests/load/results/stress-multi-room-8rooms-summary.json
@@ -1,0 +1,360 @@
+{
+  "setup_data": {
+    "rooms": [
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11
+    ]
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "WS 101",
+          "path": "::WS 101",
+          "id": "f6a7b31cd7928bedc65f8a7cf384b08c",
+          "passes": 5666,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 100411.8355
+  },
+  "metrics": {
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "avg": 0.011854961173425368,
+        "min": 0,
+        "med": 0,
+        "max": 14.6581
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 4863.939924708791,
+        "min": 2322.2108,
+        "med": 5286.9124,
+        "max": 9559.4642,
+        "p(90)": 7487.34565,
+        "p(95)": 7804.9425249999995
+      }
+    },
+    "stomp_connect_errors": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count<50": {
+          "ok": true
+        }
+      }
+    },
+    "ws_session_duration": {
+      "contains": "time",
+      "values": {
+        "p(90)": 5018.828600000001,
+        "p(95)": 5387.5002,
+        "avg": 3007.1738954465304,
+        "min": 1307.2588,
+        "med": 2986.2244,
+        "max": 7523.5985
+      },
+      "type": "trend"
+    },
+    "http_req_blocked": {
+      "contains": "time",
+      "values": {
+        "avg": 0.01610609872394533,
+        "min": 0,
+        "med": 0,
+        "max": 14.6581,
+        "p(90)": 0,
+        "p(95)": 0
+      },
+      "type": "trend"
+    },
+    "http_req_sending": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "avg": 0.024842763725534723,
+        "min": 0,
+        "med": 0,
+        "max": 126.8707,
+        "p(90)": 0
+      },
+      "type": "trend"
+    },
+    "ws_sessions": {
+      "contains": "default",
+      "values": {
+        "count": 5666,
+        "rate": 56.42761106582899
+      },
+      "type": "counter"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 278.52089846055947,
+        "min": 2.0621,
+        "med": 117.4956,
+        "max": 2368.919,
+        "p(90)": 835.4736,
+        "p(95)": 1051.3389
+      }
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_waiting": {
+      "contains": "time",
+      "values": {
+        "avg": 277.986907274873,
+        "min": 2.0621,
+        "med": 116.8671,
+        "max": 2368.919,
+        "p(90)": 835.3443,
+        "p(95)": 1051.242
+      },
+      "type": "trend"
+    },
+    "ws_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 109.1616,
+        "avg": 44.38162942110826,
+        "min": 1.0142,
+        "med": 23.13985,
+        "max": 303.8437,
+        "p(90)": 100.95660000000001
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 22021
+      },
+      "thresholds": {
+        "rate<0.05": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 5666,
+        "fails": 0
+      }
+    },
+    "ws_session_duration_ms": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 2986.3326861983765,
+        "min": 1307,
+        "med": 2950,
+        "max": 7524,
+        "p(90)": 4995.5,
+        "p(95)": 5363.75
+      },
+      "thresholds": {
+        "p(95)<15000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration": {
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 117.4956,
+        "max": 2368.919,
+        "p(90)": 835.4736,
+        "p(95)": 1051.3389,
+        "avg": 278.52089846055947,
+        "min": 2.0621
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 5666,
+        "rate": 56.42761106582899
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 8486276,
+        "rate": 84514.69846898675
+      }
+    },
+    "stomp_messages_received": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 151237,
+        "rate": 1506.1670693192339
+      },
+      "thresholds": {
+        "count>0": {
+          "ok": true
+        }
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 73674394,
+        "rate": 733722.2114618152
+      }
+    },
+    "ws_msgs_received": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 156903,
+        "rate": 1562.594680385063
+      }
+    },
+    "stomp_messages_sent": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 169.28283319748698,
+        "count": 16998
+      }
+    },
+    "ws_msgs_sent": {
+      "contains": "default",
+      "values": {
+        "count": 33996,
+        "rate": 338.56566639497396
+      },
+      "type": "counter"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 93,
+        "min": 6,
+        "max": 400
+      }
+    },
+    "ws_success_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 5666,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.80": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.5384,
+        "p(95)": 0.8171,
+        "avg": 0.5091484219608566,
+        "min": 0,
+        "med": 0,
+        "max": 103.3302
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 400,
+        "min": 400,
+        "max": 400
+      }
+    },
+    "ws_connect_errors": {
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count<50": {
+          "ok": true
+        }
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 219.30681667501239,
+        "count": 22021
+      }
+    }
+  }
+}

--- a/tests/load/results/stress-single-room-summary.json
+++ b/tests/load/results/stress-single-room-summary.json
@@ -1,0 +1,358 @@
+{
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 285942.6667
+  },
+  "metrics": {
+    "ws_connect_errors": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count<50": {
+          "ok": true
+        }
+      }
+    },
+    "ws_sessions": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 18.68206679909235,
+        "count": 5342
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 5311,
+        "rate": 18.573653457502708
+      }
+    },
+    "ws_msgs_sent": {
+      "values": {
+        "count": 27631,
+        "rate": 96.63125940204431
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "stomp_messages_received": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 552748,
+        "rate": 1933.0728302255145
+      },
+      "thresholds": {
+        "count>0": {
+          "ok": true
+        }
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 12551.613358538894,
+        "min": 2325.9924,
+        "med": 8678.586,
+        "max": 46234.7753,
+        "p(90)": 29875.8484,
+        "p(95)": 33188.75895
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.012181907653136172,
+        "min": 0,
+        "med": 0,
+        "max": 24.4948,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 71.42340888016905,
+        "count": 20423
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 69.5789,
+        "p(90)": 0,
+        "p(95)": 0,
+        "avg": 0.027652832590706566,
+        "min": 0,
+        "med": 0
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.024481594280957746,
+        "min": 0,
+        "med": 0,
+        "max": 69.5789,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 0,
+        "rate": 1,
+        "passes": 10682
+      }
+    },
+    "ws_session_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 7879.20326835205,
+        "min": 1308.3291,
+        "med": 4214.49835,
+        "max": 28895.1566,
+        "p(90)": 20410.15484,
+        "p(95)": 21314.020705
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 5086.448749999996,
+        "avg": 1130.6270562747845,
+        "min": 2.1711,
+        "med": 292.466,
+        "max": 18299.7757,
+        "p(90)": 3598.2083199999993
+      },
+      "thresholds": {
+        "p(95)<3000": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 2.975908705870834,
+        "min": 0,
+        "med": 0,
+        "max": 432.846,
+        "p(90)": 0.8528,
+        "p(95)": 1.1068399999999876
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 7323827,
+        "rate": 25612.921235304406
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1130.6270562747845,
+        "min": 2.1711,
+        "med": 292.466,
+        "max": 18299.7757,
+        "p(90)": 3598.2083199999993,
+        "p(95)": 5086.448749999996
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 5060.602459999995,
+        "avg": 1127.6389656612623,
+        "min": 0.8398,
+        "med": 291.9909,
+        "max": 18299.7757,
+        "p(90)": 3596.6960399999994
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 246706736,
+        "rate": 862783.9239494649
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "ws_success_rate": {
+      "values": {
+        "rate": 0.8389513108614233,
+        "passes": 4480,
+        "fails": 860
+      },
+      "thresholds": {
+        "rate>0.80": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "stomp_messages_sent": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 13445,
+        "rate": 47.01991540879757
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 44,
+        "min": 3,
+        "max": 500
+      }
+    },
+    "ws_msgs_received": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 557230,
+        "rate": 1948.7473010966362
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 500,
+        "min": 500,
+        "max": 500
+      }
+    },
+    "stomp_connect_errors": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 860,
+        "rate": 3.007595927970689
+      },
+      "thresholds": {
+        "count<50": {
+          "ok": false
+        }
+      }
+    },
+    "ws_session_duration_ms": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 28896,
+        "p(90)": 20411.2,
+        "p(95)": 21313.350000000002,
+        "avg": 7879.330524344569,
+        "min": 1308,
+        "med": 4214.5
+      },
+      "thresholds": {
+        "p(95)<15000": {
+          "ok": false
+        }
+      }
+    },
+    "ws_connecting": {
+      "contains": "time",
+      "values": {
+        "avg": 295.54588013852464,
+        "min": 1.0149,
+        "med": 85.0713,
+        "max": 4711.8414,
+        "p(90)": 847.6463,
+        "p(95)": 1764.2319899999986
+      },
+      "type": "trend"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 20423
+      },
+      "thresholds": {
+        "rate<0.05": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0
+      }
+    }
+  },
+  "setup_data": {
+    "roomId": 3
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "path": "::방 입장 성공",
+          "id": "4a902043e55c0d622cce3f304d16fbca",
+          "passes": 5342,
+          "fails": 0,
+          "name": "방 입장 성공"
+        },
+        {
+          "name": "WS 101",
+          "path": "::WS 101",
+          "id": "f6a7b31cd7928bedc65f8a7cf384b08c",
+          "passes": 5340,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)"
+    ],
+    "summaryTimeUnit": ""
+  }
+}

--- a/tests/load/results/websocket-stomp-summary.json
+++ b/tests/load/results/websocket-stomp-summary.json
@@ -1,0 +1,415 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [
+      {
+        "checks": [
+          {
+            "name": "세션 생성 성공",
+            "path": "::사전 준비 (REST)::세션 생성 성공",
+            "id": "3e2fad3b3228c9bf14886f7a0947bee1",
+            "passes": 2109,
+            "fails": 0
+          }
+        ],
+        "name": "사전 준비 (REST)",
+        "path": "::사전 준비 (REST)",
+        "id": "6ff2846ac44434cb479f4c010b52d167",
+        "groups": []
+      },
+      {
+        "name": "WebSocket STOMP 세션",
+        "path": "::WebSocket STOMP 세션",
+        "id": "3a9973ee779544ac7957e540ccf88903",
+        "groups": [],
+        "checks": [
+            {
+              "name": "STOMP CONNECTED 수신",
+              "path": "::WebSocket STOMP 세션::STOMP CONNECTED 수신",
+              "id": "be158c2a560edf92e29062503b7b052e",
+              "passes": 2109,
+              "fails": 0
+            },
+            {
+              "fails": 0,
+              "name": "STOMP 세션 정상 완료",
+              "path": "::WebSocket STOMP 세션::STOMP 세션 정상 완료",
+              "id": "be847c73eb435aee7521fecff666851d",
+              "passes": 2109
+            },
+            {
+              "name": "메시지 전송 성공",
+              "path": "::WebSocket STOMP 세션::메시지 전송 성공",
+              "id": "9927c368b1e7343564bc3f6784904f72",
+              "passes": 2109,
+              "fails": 0
+            },
+            {
+              "name": "WebSocket 101",
+              "path": "::WebSocket STOMP 세션::WebSocket 101",
+              "id": "9957c65575327ef1c43509e41d597ad0",
+              "passes": 2109,
+              "fails": 0
+            }
+          ]
+      }
+    ],
+    "checks": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 61062.9653
+  },
+  "metrics": {
+    "ws_success_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 2109,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.98": {
+          "ok": true
+        }
+      }
+    },
+    "stomp_messages_sent": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 10545,
+        "rate": 172.69059810955494
+      }
+    },
+    "ws_session_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 1614.9002,
+        "med": 3293.2102,
+        "max": 6683.3057,
+        "p(90)": 4678.098760000001,
+        "p(95)": 5009.57804,
+        "avg": 3301.789903366521
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 10545,
+        "fails": 0
+      }
+    },
+    "ws_connect_errors": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "thresholds": {
+        "count<10": {
+          "ok": true
+        }
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 200,
+        "min": 200,
+        "max": 200
+      }
+    },
+    "ws_connecting": {
+      "values": {
+        "avg": 56.11493138928401,
+        "min": 1.5244,
+        "med": 61.7227,
+        "max": 301.1809,
+        "p(90)": 108.57754,
+        "p(95)": 124.90065999999996
+      },
+      "thresholds": {
+        "p(95)<1000": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 8299,
+        "rate": 135.90889271798923
+      }
+    },
+    "stomp_messages_received": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 212578,
+        "rate": 3481.2917937347534
+      },
+      "thresholds": {
+        "count>0": {
+          "ok": true
+        }
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2109,
+        "rate": 34.538119621910994
+      }
+    },
+    "ws_msgs_received": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 214687,
+        "rate": 3515.8299133566643
+      }
+    },
+    "stomp_connect_errors": {
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "count": 0
+      },
+      "thresholds": {
+        "count<10": {
+          "ok": true
+        }
+      },
+      "type": "counter"
+    },
+    "http_req_duration{expected_response:true}": {
+      "values": {
+        "avg": 216.08915066875528,
+        "min": 4.9006,
+        "med": 124.9529,
+        "max": 1587.632,
+        "p(90)": 556.7275,
+        "p(95)": 723.4578299999998
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 4.677,
+        "med": 124.6212,
+        "max": 1587.632,
+        "p(90)": 556.1231999999999,
+        "p(95)": 722.0735899999999,
+        "avg": 215.36345693457056
+      }
+    },
+    "iteration_duration": {
+      "values": {
+        "min": 2637.0473,
+        "med": 5207.5875,
+        "max": 9248.7196,
+        "p(90)": 6781.68746,
+        "p(95)": 7081.3827,
+        "avg": 5017.5486839734485
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 723.4578299999998,
+        "avg": 216.08915066875528,
+        "min": 4.9006,
+        "med": 124.9529,
+        "max": 1587.632,
+        "p(90)": 556.7275
+      },
+      "thresholds": {
+        "p(95)<500": {
+          "ok": false
+        }
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 4034828,
+        "rate": 66076.51594017823
+      }
+    },
+    "ws_msgs_sent": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 16872,
+        "rate": 276.30495697528795
+      }
+    },
+    "ws_sessions": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2109,
+        "rate": 34.538119621910994
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "max": 6.3489,
+        "p(90)": 0,
+        "p(95)": 0,
+        "avg": 0.01388769731292927
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "max": 3.9909,
+        "p(90)": 0,
+        "p(95)": 0,
+        "avg": 0.009280033739004701,
+        "min": 0
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "max": 20.0268,
+        "p(90)": 0,
+        "p(95)": 0,
+        "avg": 0.017010543438968552
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.7086831907458735,
+        "min": 0,
+        "med": 0,
+        "max": 401.1491,
+        "p(90)": 0.5208200000000001,
+        "p(95)": 0.831069999999998
+      }
+    },
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 8299
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "ws_session_duration_ms": {
+      "contains": "time",
+      "values": {
+        "avg": 3300.7752489331438,
+        "min": 1615,
+        "med": 3291,
+        "max": 6683,
+        "p(90)": 4674,
+        "p(95)": 5009.6
+      },
+      "thresholds": {
+        "p(95)<5000": {
+          "ok": false
+        }
+      },
+      "type": "trend"
+    },
+    "group_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1822.936179042196,
+        "min": 13.1101,
+        "med": 1616.7813,
+        "max": 6683.3057,
+        "p(90)": 4132.59767,
+        "p(95)": 4678.0688599999985
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 200,
+        "value": 43,
+        "min": 18
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 96700525,
+        "rate": 1583619.8672127048
+      }
+    }
+  },
+  "setup_data": {
+    "rooms": [
+      1,
+      2
+    ]
+  }
+}

--- a/tests/load/scenarios.js
+++ b/tests/load/scenarios.js
@@ -1,0 +1,226 @@
+/**
+ * 통합 시나리오 부하테스트 (k6)
+ *
+ * REST API와 WebSocket/STOMP를 동시에 실행하여 실제 사용 패턴을 시뮬레이션합니다.
+ *
+ *  - rest_users  : REST API 전용 (방 목록 조회, 입장, 메시지 이력)
+ *  - ws_chatters : WebSocket 채팅 (실시간 메시지 전송)
+ *
+ * 실행:
+ *   k6 run tests/load/scenarios.js
+ *   k6 run --out csv=tests/load/results/metrics.csv tests/load/scenarios.js
+ */
+
+import http from 'k6/http';
+import ws   from 'k6/ws';
+import { check, sleep, group } from 'k6';
+import { Counter, Rate } from 'k6/metrics';
+import { API_URL, WS_URL, THRESHOLDS } from './config.js';
+
+const totalErrors    = new Counter('total_errors');
+const overallSuccess = new Rate('overall_success_rate');
+
+export const options = {
+  scenarios: {
+    rest_users: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 20 },
+        { duration: '1m',  target: 50 },
+        { duration: '2m',  target: 50 },
+        { duration: '30s', target: 0 },
+      ],
+      exec: 'restUserScenario',
+      gracefulRampDown: '10s',
+    },
+    ws_chatters: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 10 },
+        { duration: '1m',  target: 30 },
+        { duration: '2m',  target: 30 },
+        { duration: '30s', target: 0 },
+      ],
+      exec: 'wsChatterScenario',
+      gracefulRampDown: '15s',
+    },
+  },
+  thresholds: {
+    ...THRESHOLDS,
+    total_errors:         ['count<50'],
+    overall_success_rate: ['rate>0.98'],
+  },
+};
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+// ─────────────────────────────────────────
+// 공통 유틸
+// ─────────────────────────────────────────
+function createUser() {
+  const res = http.post(
+    `${API_URL}/users`,
+    JSON.stringify({ nickname: `sc_user_${__VU}_${__ITER}` }),
+    { headers: JSON_HEADERS },
+  );
+  if (res.status < 200 || res.status >= 300) return null;
+  return res.json().id || null;
+}
+
+function createRoom(userId) {
+  const res = http.post(
+    `${API_URL}/chat-rooms`,
+    JSON.stringify({ name: `sc_room_${__VU}_${__ITER}`, creatorId: userId }),
+    { headers: JSON_HEADERS },
+  );
+  if (res.status < 200 || res.status >= 300) return null;
+  return res.json().id || null;
+}
+
+function joinRoom(roomId, userId) {
+  const res = http.post(
+    `${API_URL}/chat-rooms/${roomId}/join?userId=${userId}`,
+    null,
+    { headers: JSON_HEADERS },
+  );
+  return res.status === 200;
+}
+
+// ─────────────────────────────────────────
+// STOMP 프레임 유틸
+// ─────────────────────────────────────────
+function stompFrame(command, headers, body = '') {
+  let frame = command + '\n';
+  for (const [k, v] of Object.entries(headers)) {
+    frame += `${k}:${v}\n`;
+  }
+  return frame + '\n' + body + '\0';
+}
+
+// ─────────────────────────────────────────
+// 시나리오 1: REST 전용 유저
+// ─────────────────────────────────────────
+export function restUserScenario() {
+  const userId = createUser();
+  if (!userId) { totalErrors.add(1); sleep(1); return; }
+
+  group('방 목록 조회', () => {
+    const res = http.get(`${API_URL}/chat-rooms?userId=${userId}`);
+    const ok = check(res, { '목록 200': (r) => r.status === 200 });
+    overallSuccess.add(ok);
+    if (!ok) totalErrors.add(1);
+  });
+
+  const roomId = createRoom(userId);
+  if (!roomId) { totalErrors.add(1); sleep(1); return; }
+
+  group('방 입장 + 메시지 이력', () => {
+    const ok1 = joinRoom(roomId, userId);
+    check(ok1, { '입장 성공': (v) => v === true });
+    overallSuccess.add(ok1);
+    if (!ok1) { totalErrors.add(1); return; }
+
+    const msgRes = http.get(`${API_URL}/messages/chatroom/${roomId}`);
+    const ok2 = check(msgRes, { '이력 200': (r) => r.status === 200 });
+    overallSuccess.add(ok2);
+    if (!ok2) totalErrors.add(1);
+  });
+
+  group('방 퇴장', () => {
+    const res = http.post(
+      `${API_URL}/chat-rooms/${roomId}/leave?userId=${userId}`,
+      null,
+      { headers: JSON_HEADERS },
+    );
+    const ok = check(res, { '퇴장 204': (r) => r.status === 204 });
+    overallSuccess.add(ok);
+    if (!ok) totalErrors.add(1);
+  });
+
+  sleep(2);
+}
+
+// ─────────────────────────────────────────
+// 시나리오 2: WebSocket 채팅 유저
+// ─────────────────────────────────────────
+export function wsChatterScenario() {
+  const userId = createUser();
+  const roomId = createRoom(userId);
+  if (!userId || !roomId) { totalErrors.add(1); sleep(1); return; }
+
+  if (!joinRoom(roomId, userId)) { totalErrors.add(1); sleep(1); return; }
+
+  group('WebSocket 채팅', () => {
+    let connected = false;
+    let sent = 0;
+
+    const res = ws.connect(WS_URL, {}, (socket) => {
+      socket.on('open', () => {
+        socket.send(stompFrame('CONNECT', {
+          'accept-version': '1.2',
+          'heart-beat': '0,0',
+          host: 'localhost',
+        }));
+      });
+
+      socket.on('message', (data) => {
+        const cmd = (data.split('\n')[0] || '').trim();
+
+        if (cmd === 'CONNECTED') {
+          connected = true;
+          socket.send(stompFrame('SUBSCRIBE', {
+            id: 'sub-0',
+            destination: `/topic/room/${roomId}`,
+            ack: 'auto',
+          }));
+
+          let cnt = 0;
+          const tick = () => {
+            if (cnt >= 3) {
+              socket.send(stompFrame('DISCONNECT', { receipt: 'bye' }));
+              socket.close();
+              return;
+            }
+            socket.send(stompFrame(
+              'SEND',
+              { destination: '/app/chat.message', 'content-type': 'application/json' },
+              JSON.stringify({
+                roomId, userId,
+                messageType: 'TEXT',
+                content: `통합테스트 ${cnt + 1} VU${__VU}`,
+                attachmentUrl: null,
+              }),
+            ));
+            sent++;
+            cnt++;
+            socket.setTimeout(tick, 300);
+          };
+          socket.setTimeout(tick, 200);
+        }
+
+        if (cmd === 'ERROR') {
+          totalErrors.add(1);
+          socket.close();
+        }
+      });
+
+      socket.on('error', () => { totalErrors.add(1); });
+      socket.setTimeout(() => socket.close(), 10000);
+    });
+
+    const ok = check(res, { 'WS 101': (r) => r && r.status === 101 }) && connected;
+    overallSuccess.add(ok);
+    if (!ok) totalErrors.add(1);
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    'tests/load/results/scenarios-summary.json': JSON.stringify(data, null, 2),
+    stdout: '\n=== 부하테스트 완료 ===\n결과: tests/load/results/scenarios-summary.json\n',
+  };
+}

--- a/tests/load/stress-multi-room.js
+++ b/tests/load/stress-multi-room.js
@@ -1,0 +1,188 @@
+/**
+ * 다중 채팅방 시스템 용량 스트레스 테스트
+ *
+ * 목적: 방당 고정 인원으로 방 수를 늘려 전체 시스템 용량 측정
+ * 시나리오:
+ *   - USERS_PER_ROOM = 50  고정
+ *   - 방 수 2 → 4 → 8 → 12개로 증가 (총 VU: 100 → 200 → 400 → 600)
+ *
+ * 실행 시 환경변수로 방 수 조정 가능:
+ *   k6 run -e ROOM_COUNT=10 tests/load/stress-multi-room.js
+ */
+
+import http from 'k6/http';
+import ws   from 'k6/ws';
+import { check, sleep, group } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { API_URL, WS_URL } from './config.js';
+
+const wsConnectErrors  = new Counter('ws_connect_errors');
+const stompConnErrors  = new Counter('stomp_connect_errors');
+const msgSentCount     = new Counter('stomp_messages_sent');
+const msgReceivedCount = new Counter('stomp_messages_received');
+const wsSessionDuration = new Trend('ws_session_duration_ms', true);
+const wsSuccessRate    = new Rate('ws_success_rate');
+
+const USERS_PER_ROOM = 50;
+const ROOM_COUNT     = parseInt(__ENV.ROOM_COUNT || '8');
+const TOTAL_VUS      = USERS_PER_ROOM * ROOM_COUNT;
+const MSG_SEND_COUNT = 3;
+const JSON_HEADERS   = { 'Content-Type': 'application/json' };
+
+export const options = {
+  stages: [
+    { duration: '15s', target: Math.floor(TOTAL_VUS * 0.25) },
+    { duration: '15s', target: Math.floor(TOTAL_VUS * 0.50) },
+    { duration: '15s', target: TOTAL_VUS },
+    { duration: '40s', target: TOTAL_VUS },  // 피크 유지
+    { duration: '15s', target: 0 },
+  ],
+  thresholds: {
+    ws_connect_errors:       ['count<50'],
+    stomp_connect_errors:    ['count<50'],
+    ws_success_rate:         ['rate>0.80'],
+    ws_session_duration_ms:  ['p(95)<15000'],
+    stomp_messages_received: ['count>0'],
+    http_req_failed:         ['rate<0.05'],
+    http_req_duration:       ['p(95)<3000'],
+  },
+};
+
+function stompFrame(command, headers, body = '') {
+  let frame = command + '\n';
+  for (const [k, v] of Object.entries(headers)) frame += `${k}:${v}\n`;
+  return frame + '\n' + body + '\0';
+}
+
+export function setup() {
+  const coordRes = http.post(
+    `${API_URL}/users`,
+    { nickname: 'multi_coord' },
+  );
+  const coordId = coordRes.json().id;
+
+  const rooms = [];
+  for (let i = 0; i < ROOM_COUNT; i++) {
+    const roomRes = http.post(
+      `${API_URL}/chat-rooms`,
+      { name: `multi_room_${i}`, creatorId: coordId },
+    );
+    if (roomRes.status >= 200 && roomRes.status < 300) {
+      const id = roomRes.json().id;
+      if (id) rooms.push(id);
+    }
+  }
+  if (rooms.length === 0) throw new Error('방 생성 실패');
+  console.log(`[setup] 방 ${rooms.length}개 생성 (방당 ${USERS_PER_ROOM}명 목표, 총 VU: ${TOTAL_VUS}): ${rooms.join(', ')}`);
+  return { rooms };
+}
+
+export default function ({ rooms }) {
+  // VU 번호 기준으로 방 배정 (균등 분산)
+  const roomId = rooms[(__VU - 1) % rooms.length];
+
+  const userRes = http.post(
+    `${API_URL}/users`,
+    { nickname: `multi_u_${__VU}_${__ITER}` },
+  );
+  if (userRes.status < 200 || userRes.status >= 300) { wsConnectErrors.add(1); sleep(1); return; }
+  const userId = userRes.json().id;
+  if (!userId) { wsConnectErrors.add(1); sleep(1); return; }
+
+  const joinRes = http.post(
+    `${API_URL}/chat-rooms/${roomId}/join?userId=${userId}`,
+    null,
+    { headers: JSON_HEADERS },
+  );
+  if (joinRes.status !== 200) { wsConnectErrors.add(1); sleep(1); return; }
+
+  const sessionStart = Date.now();
+  let stompConnected = false;
+  let sentCount = 0;
+  let lastMsgId = null;
+
+  const res = ws.connect(WS_URL, {}, (socket) => {
+    socket.on('open', () => {
+      socket.send(stompFrame('CONNECT', {
+        'accept-version': '1.2,1.1',
+        'heart-beat': '0,0',
+        host: 'localhost',
+      }));
+    });
+
+    socket.on('message', (raw) => {
+      const cmd = (raw.split('\n')[0] || '').trim();
+
+      if (cmd === 'CONNECTED') {
+        stompConnected = true;
+        socket.send(stompFrame('SUBSCRIBE', {
+          id: 'sub-0',
+          destination: `/topic/chatroom/${roomId}`,
+          ack: 'auto',
+        }));
+        let cnt = 0;
+        const sendNext = () => {
+          if (cnt >= MSG_SEND_COUNT) {
+            if (lastMsgId) {
+              http.post(
+                `${API_URL}/read-status/mark-read?userId=${userId}&chatRoomId=${roomId}`,
+                null, { headers: JSON_HEADERS },
+              );
+            }
+            socket.setTimeout(() => {
+              socket.send(stompFrame('DISCONNECT', { receipt: 'dr' }));
+              socket.close();
+            }, 200);
+            return;
+          }
+          socket.send(stompFrame(
+            'SEND',
+            { destination: '/app/chat.sendMessage', 'content-type': 'application/json' },
+            JSON.stringify({ chatRoomId: roomId, senderId: userId, messageType: 'TEXT',
+              content: `부하 ${cnt + 1} VU${__VU} room${roomId}` }),
+          ));
+          msgSentCount.add(1);
+          sentCount++;
+          cnt++;
+          socket.setTimeout(sendNext, 300);
+        };
+        socket.setTimeout(sendNext, 200);
+      }
+
+      if (cmd === 'MESSAGE') {
+        msgReceivedCount.add(1);
+        try {
+          const bi = raw.lastIndexOf('\n\n');
+          if (bi !== -1) {
+            const body = JSON.parse(raw.substring(bi + 2).replace('\0', ''));
+            if (body.id) lastMsgId = body.id;
+          }
+        } catch (_) {}
+      }
+
+      if (cmd === 'ERROR') { stompConnErrors.add(1); socket.close(); }
+    });
+
+    socket.on('error', () => wsConnectErrors.add(1));
+    socket.on('close', () => {
+      wsSessionDuration.add(Date.now() - sessionStart);
+      wsSuccessRate.add(stompConnected && sentCount > 0);
+    });
+    socket.setTimeout(() => { if (!stompConnected) stompConnErrors.add(1); socket.close(); }, 20000);
+  });
+
+  check(res, { 'WS 101': (r) => r && r.status === 101 });
+  if (!res || res.status !== 101) wsConnectErrors.add(1);
+
+  http.post(`${API_URL}/chat-rooms/${roomId}/leave?userId=${userId}`, null, { headers: JSON_HEADERS });
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  const roomCount = data.setup_data ? data.setup_data.rooms.length : ROOM_COUNT;
+  const filename = `tests/load/results/stress-multi-room-${roomCount}rooms-summary.json`;
+  return {
+    [filename]: JSON.stringify(data, null, 2),
+    stdout: `\n=== 다중 방 스트레스 테스트 완료 (${roomCount}방 × ${USERS_PER_ROOM}명) ===\n결과: ${filename}\n`,
+  };
+}

--- a/tests/load/stress-single-room.js
+++ b/tests/load/stress-single-room.js
@@ -1,0 +1,187 @@
+/**
+ * 단일 채팅방 최대 동시 접속 스트레스 테스트
+ *
+ * 목적: 채팅방 1개에서 VU를 점진적으로 증가시켜 한계점 측정
+ * 단계: 50 → 100 → 200 → 350 → 500 VU
+ * 임계값: 에러율·응답시간이 언제 기준을 초과하는지 관찰
+ */
+
+import http from 'k6/http';
+import ws   from 'k6/ws';
+import { check, sleep, group } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { API_URL, WS_URL } from './config.js';
+
+const wsConnectErrors  = new Counter('ws_connect_errors');
+const stompConnErrors  = new Counter('stomp_connect_errors');
+const msgSentCount     = new Counter('stomp_messages_sent');
+const msgReceivedCount = new Counter('stomp_messages_received');
+const wsSessionDuration = new Trend('ws_session_duration_ms', true);
+const wsSuccessRate    = new Rate('ws_success_rate');
+
+const MSG_SEND_COUNT = 3;  // 빠른 순환을 위해 3건으로 축소
+const JSON_HEADERS   = { 'Content-Type': 'application/json' };
+
+export const options = {
+  // 단일 방에 VU를 단계적으로 증가
+  stages: [
+    { duration: '20s', target: 50  },
+    { duration: '30s', target: 50  },
+    { duration: '20s', target: 100 },
+    { duration: '30s', target: 100 },
+    { duration: '20s', target: 200 },
+    { duration: '30s', target: 200 },
+    { duration: '20s', target: 350 },
+    { duration: '30s', target: 350 },
+    { duration: '20s', target: 500 },
+    { duration: '30s', target: 500 },
+    { duration: '20s', target: 0   },
+  ],
+  // 임계값 완화: 한계를 관찰하는 것이 목적이므로 실패해도 테스트 계속 진행
+  thresholds: {
+    ws_connect_errors:       ['count<50'],
+    stomp_connect_errors:    ['count<50'],
+    ws_success_rate:         ['rate>0.80'],   // 완화: 80% 이상
+    ws_session_duration_ms:  ['p(95)<15000'], // 완화: 15초 이내
+    stomp_messages_received: ['count>0'],
+    http_req_failed:         ['rate<0.05'],   // 완화: 5% 미만
+    http_req_duration:       ['p(95)<3000'],  // 완화: 3초 이내
+  },
+};
+
+function stompFrame(command, headers, body = '') {
+  let frame = command + '\n';
+  for (const [k, v] of Object.entries(headers)) frame += `${k}:${v}\n`;
+  return frame + '\n' + body + '\0';
+}
+
+export function setup() {
+  const coordRes = http.post(
+    `${API_URL}/users`,
+    { nickname: 'stress_coord' },
+  );
+  const coordId = coordRes.json().id;
+
+  const roomRes = http.post(
+    `${API_URL}/chat-rooms`,
+    { name: 'stress_single_room', creatorId: coordId },
+  );
+  const roomId = roomRes.json().id;
+  if (!roomId) throw new Error('채팅방 생성 실패');
+  console.log(`[setup] 단일 스트레스 방 생성: roomId=${roomId}`);
+  return { roomId };
+}
+
+export default function ({ roomId }) {
+  // 사용자 생성 및 입장
+  const userRes = http.post(
+    `${API_URL}/users`,
+    { nickname: `stress_u_${__VU}_${__ITER}` },
+  );
+  if (userRes.status < 200 || userRes.status >= 300) {
+    wsConnectErrors.add(1);
+    sleep(1);
+    return;
+  }
+  const userId = userRes.json().id;
+  if (!userId) { wsConnectErrors.add(1); sleep(1); return; }
+
+  const joinRes = http.post(
+    `${API_URL}/chat-rooms/${roomId}/join?userId=${userId}`,
+    null,
+    { headers: JSON_HEADERS },
+  );
+  check(joinRes, { '방 입장 성공': (r) => r.status === 200 });
+  if (joinRes.status !== 200) { wsConnectErrors.add(1); sleep(1); return; }
+
+  // WebSocket STOMP 세션
+  const sessionStart = Date.now();
+  let stompConnected = false;
+  let sentCount = 0;
+  let lastMsgId = null;
+
+  const res = ws.connect(WS_URL, {}, (socket) => {
+    socket.on('open', () => {
+      socket.send(stompFrame('CONNECT', {
+        'accept-version': '1.2,1.1',
+        'heart-beat': '0,0',
+        host: 'localhost',
+      }));
+    });
+
+    socket.on('message', (raw) => {
+      const cmd = (raw.split('\n')[0] || '').trim();
+
+      if (cmd === 'CONNECTED') {
+        stompConnected = true;
+        socket.send(stompFrame('SUBSCRIBE', {
+          id: 'sub-0',
+          destination: `/topic/chatroom/${roomId}`,
+          ack: 'auto',
+        }));
+        let cnt = 0;
+        const sendNext = () => {
+          if (cnt >= MSG_SEND_COUNT) {
+            if (lastMsgId) {
+              http.post(
+                `${API_URL}/read-status/mark-read?userId=${userId}&chatRoomId=${roomId}`,
+                null, { headers: JSON_HEADERS },
+              );
+            }
+            socket.setTimeout(() => {
+              socket.send(stompFrame('DISCONNECT', { receipt: 'dr' }));
+              socket.close();
+            }, 200);
+            return;
+          }
+          socket.send(stompFrame(
+            'SEND',
+            { destination: '/app/chat.sendMessage', 'content-type': 'application/json' },
+            JSON.stringify({ chatRoomId: roomId, senderId: userId, messageType: 'TEXT',
+              content: `부하 ${cnt + 1} VU${__VU}` }),
+          ));
+          msgSentCount.add(1);
+          sentCount++;
+          cnt++;
+          socket.setTimeout(sendNext, 300);
+        };
+        socket.setTimeout(sendNext, 200);
+      }
+
+      if (cmd === 'MESSAGE') {
+        msgReceivedCount.add(1);
+        try {
+          const bi = raw.lastIndexOf('\n\n');
+          if (bi !== -1) {
+            const body = JSON.parse(raw.substring(bi + 2).replace('\0', ''));
+            if (body.id) lastMsgId = body.id;
+          }
+        } catch (_) {}
+      }
+
+      if (cmd === 'ERROR') { stompConnErrors.add(1); socket.close(); }
+    });
+
+    socket.on('error', () => wsConnectErrors.add(1));
+
+    socket.on('close', () => {
+      wsSessionDuration.add(Date.now() - sessionStart);
+      wsSuccessRate.add(stompConnected && sentCount > 0);
+    });
+
+    socket.setTimeout(() => { if (!stompConnected) stompConnErrors.add(1); socket.close(); }, 20000);
+  });
+
+  check(res, { 'WS 101': (r) => r && r.status === 101 });
+  if (!res || res.status !== 101) wsConnectErrors.add(1);
+
+  http.post(`${API_URL}/chat-rooms/${roomId}/leave?userId=${userId}`, null, { headers: JSON_HEADERS });
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    'tests/load/results/stress-single-room-summary.json': JSON.stringify(data, null, 2),
+    stdout: '\n=== 단일 방 스트레스 테스트 완료 ===\n결과: tests/load/results/stress-single-room-summary.json\n',
+  };
+}

--- a/tests/load/websocket-stomp.js
+++ b/tests/load/websocket-stomp.js
@@ -1,0 +1,260 @@
+/**
+ * WebSocket/STOMP 부하테스트 - 공유 방 시나리오 (k6)
+ *
+ * 테스트 시나리오:
+ *   [setup] 공유 채팅방 10개 사전 생성
+ *   [VU]  1. 사용자 생성 → 랜덤 공유 방 입장 (REST)
+ *         2. WebSocket 연결 (/ws-stomp)
+ *         3. STOMP CONNECT 핸드셰이크
+ *         4. /topic/room/{roomId} 구독 (같은 방 다른 유저 메시지 수신)
+ *         5. /app/chat.message 로 메시지 반복 전송 → 구독자 전체 브로드캐스트
+ *         6. /app/chat.read 읽음 처리
+ *         7. STOMP DISCONNECT → 방 퇴장
+ *
+ * 실행:
+ *   k6 run tests/load/websocket-stomp.js
+ */
+
+import http from 'k6/http';
+import ws   from 'k6/ws';
+import { check, sleep, group } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { API_URL, WS_URL, THRESHOLDS } from './config.js';
+
+// 커스텀 메트릭
+const wsConnectErrors   = new Counter('ws_connect_errors');
+const stompConnErrors   = new Counter('stomp_connect_errors');
+const msgSentCount      = new Counter('stomp_messages_sent');
+const msgReceivedCount  = new Counter('stomp_messages_received');
+const wsSessionDuration = new Trend('ws_session_duration_ms', true);
+const wsSuccessRate     = new Rate('ws_success_rate');
+
+// 공유 방 개수 (200 VU ÷ 2방 = 방당 100명 동시 채팅)
+const SHARED_ROOM_COUNT = 2;
+const MSG_SEND_COUNT    = 5;
+const JSON_HEADERS      = { 'Content-Type': 'application/json' };
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 200 }, // 10초 만에 200 VU
+    { duration: '40s', target: 200 }, // 40초 유지
+    { duration: '10s', target: 0   }, // 10초 감소
+  ],
+  thresholds: {
+    ...THRESHOLDS,
+    ws_connect_errors:        ['count<10'],
+    stomp_connect_errors:     ['count<10'],
+    ws_success_rate:          ['rate>0.98'],
+    ws_session_duration_ms:   ['p(95)<5000'],
+    stomp_messages_received:  ['count>0'],
+  },
+};
+
+// ─────────────────────────────────────────
+// STOMP 프레임 유틸리티
+// ─────────────────────────────────────────
+function stompFrame(command, headers, body = '') {
+  let frame = command + '\n';
+  for (const [k, v] of Object.entries(headers)) {
+    frame += `${k}:${v}\n`;
+  }
+  frame += '\n' + body + '\0';
+  return frame;
+}
+
+// ─────────────────────────────────────────
+// setup: 테스트 시작 전 공유 방 N개 생성 (1회 실행)
+// ─────────────────────────────────────────
+export function setup() {
+  const coordRes = http.post(
+    `${API_URL}/users`,
+    { nickname: 'load_coordinator' },
+  );
+  if (coordRes.status < 200 || coordRes.status >= 300) {
+    throw new Error(`코디네이터 유저 생성 실패: ${coordRes.status}`);
+  }
+  const coordId = coordRes.json().id;
+
+  const rooms = [];
+  for (let i = 0; i < SHARED_ROOM_COUNT; i++) {
+    const roomRes = http.post(
+      `${API_URL}/chat-rooms`,
+      { name: `shared_room_${i}`, creatorId: coordId },
+    );
+    if (roomRes.status < 200 || roomRes.status >= 300) continue;
+    const roomId = roomRes.json().id;
+    if (roomId) rooms.push(roomId);
+  }
+
+  if (rooms.length === 0) throw new Error('공유 방 생성 실패');
+  console.log(`[setup] 공유 방 ${rooms.length}개 생성 완료: ${rooms.join(', ')}`);
+  return { rooms };
+}
+
+// ─────────────────────────────────────────
+// REST 사전 준비: 사용자 생성 → 랜덤 공유 방 입장
+// ─────────────────────────────────────────
+function setupSession(rooms) {
+  const userRes = http.post(
+    `${API_URL}/users`,
+    { nickname: `ws_user_${__VU}_${__ITER}` },
+  );
+  if (userRes.status < 200 || userRes.status >= 300) return null;
+  const userId = userRes.json().id;
+  if (!userId) return null;
+
+  // 랜덤 공유 방 선택 (20명씩 분산)
+  const roomId = rooms[(__VU - 1) % rooms.length];
+
+  const joinRes = http.post(
+    `${API_URL}/chat-rooms/${roomId}/join?userId=${userId}`,
+    null,
+    { headers: JSON_HEADERS },
+  );
+  if (joinRes.status !== 200) return null;
+
+  return { userId, roomId };
+}
+
+// ─────────────────────────────────────────
+// 메인 VU 시나리오
+// ─────────────────────────────────────────
+export default function (data) {
+  const { rooms } = data;
+
+  let session;
+  group('사전 준비 (REST)', () => {
+    session = setupSession(rooms);
+    check(session, { '세션 생성 성공': (s) => s !== null });
+  });
+
+  if (!session) {
+    wsConnectErrors.add(1);
+    sleep(1);
+    return;
+  }
+
+  const { userId, roomId } = session;
+
+  group('WebSocket STOMP 세션', () => {
+    const sessionStart = Date.now();
+    let stompConnected = false;
+    let lastMsgId      = null;
+    let sentCount      = 0;
+
+    const res = ws.connect(WS_URL, {}, (socket) => {
+      socket.on('open', () => {
+        socket.send(stompFrame('CONNECT', {
+          'accept-version': '1.2,1.1',
+          'heart-beat': '10000,10000',
+          host: 'localhost',
+        }));
+      });
+
+      socket.on('message', (rawData) => {
+        const cmd = (rawData.split('\n')[0] || '').trim();
+
+        if (cmd === 'CONNECTED') {
+          stompConnected = true;
+          check(cmd, { 'STOMP CONNECTED 수신': (c) => c === 'CONNECTED' });
+
+          // 공유 방 구독 (다른 VU의 메시지도 여기서 수신됨)
+          socket.send(stompFrame('SUBSCRIBE', {
+            id: 'sub-0',
+            destination: `/topic/chatroom/${roomId}`,
+            ack: 'auto',
+          }));
+
+          // 메시지 반복 전송
+          let cnt = 0;
+          const sendNext = () => {
+            if (cnt >= MSG_SEND_COUNT) {
+              if (lastMsgId) {
+                // 읽음 처리는 REST API로 (STOMP 핸들러 없음)
+                http.post(
+                  `${API_URL}/read-status/mark-read?userId=${userId}&chatRoomId=${roomId}`,
+                  null,
+                  { headers: JSON_HEADERS },
+                );
+              }
+              socket.setTimeout(() => {
+                socket.send(stompFrame('DISCONNECT', { receipt: 'disconnect-receipt' }));
+                socket.close();
+              }, 300);
+              return;
+            }
+            socket.send(stompFrame(
+              'SEND',
+              { destination: '/app/chat.sendMessage', 'content-type': 'application/json' },
+              JSON.stringify({
+                chatRoomId: roomId,
+                senderId:   userId,
+                messageType: 'TEXT',
+                content: `부하테스트 메시지 ${cnt + 1} VU${__VU}`,
+              }),
+            ));
+            msgSentCount.add(1);
+            sentCount++;
+            cnt++;
+            socket.setTimeout(sendNext, 200);
+          };
+          socket.setTimeout(sendNext, 300);
+        }
+
+        if (cmd === 'MESSAGE') {
+          // 자신 + 같은 방 다른 유저의 메시지 수신 (브로드캐스트 확인)
+          msgReceivedCount.add(1);
+          try {
+            const bodyStart = rawData.lastIndexOf('\n\n');
+            if (bodyStart !== -1) {
+              const bodyJson = rawData.substring(bodyStart + 2).replace('\0', '');
+              const body = JSON.parse(bodyJson);
+              if (body.id) lastMsgId = body.id;
+            }
+          } catch (_) { /* 파싱 실패 무시 */ }
+        }
+
+        if (cmd === 'ERROR') {
+          stompConnErrors.add(1);
+          socket.close();
+        }
+      });
+
+      socket.on('error', () => { wsConnectErrors.add(1); });
+
+      socket.on('close', () => {
+        wsSessionDuration.add(Date.now() - sessionStart);
+        const ok = stompConnected && sentCount > 0;
+        wsSuccessRate.add(ok);
+        check(ok, {
+          'STOMP 세션 정상 완료': (v) => v === true,
+          '메시지 전송 성공':     () => sentCount > 0,
+        });
+      });
+
+      socket.setTimeout(() => {
+        if (!stompConnected) stompConnErrors.add(1);
+        socket.close();
+      }, 15000);
+    });
+
+    check(res, { 'WebSocket 101': (r) => r && r.status === 101 });
+    if (!res || res.status !== 101) wsConnectErrors.add(1);
+  });
+
+  // 방 퇴장
+  http.post(
+    `${API_URL}/chat-rooms/${roomId}/leave?userId=${userId}`,
+    null,
+    { headers: JSON_HEADERS },
+  );
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    'tests/load/results/websocket-stomp-summary.json': JSON.stringify(data, null, 2),
+    stdout: '\n=== 부하테스트 완료 (공유 방 시나리오) ===\n결과: tests/load/results/websocket-stomp-summary.json\n',
+  };
+}


### PR DESCRIPTION
## 🔗 관련 이슈 / SPEC

- Closes #7

---

## 📝 변경 사항 요약

### 추가
- `tests/load/config.js`: k6 공통 설정 — BASE_URL, WS_URL, 성능 임계값 (p95 500ms, 실패율 1% 미만)
- `tests/load/rest-api.js`: REST API 부하 테스트 — 사용자 등록, 채팅방 목록/입장, 메시지 이력 조회
- `tests/load/websocket-stomp.js`: WebSocket STOMP 실시간 메시지 부하 테스트
- `tests/load/stress-single-room.js`: 단일 채팅방 스트레스 테스트
- `tests/load/stress-multi-room.js`: 다중 채팅방(8개) 스트레스 테스트
- `tests/load/scenarios.js`: 시나리오 정의 모음
- `tests/load/results/*.json`: 각 시나리오 실행 결과 요약 (3종)
- `tests/example.spec.js`: Playwright 기본 예시 스펙

---

## ✅ 테스트 실행 결과

> PR 생성 전 로컬에서 모두 실행 후 결과를 기록합니다.

### Server 단위 테스트 (`./gradlew test`)
- [ ] 해당 없음 — 서버 코드 변경 없음

### Client 단위 테스트 (`npm test`)
- [ ] 해당 없음 — 클라이언트 코드 변경 없음

### E2E 테스트 (`cd client && npx playwright test`)
- [ ] 해당 없음 — 부하 테스트 스크립트 추가 (k6 실행 환경 별도 필요)

---

## 🤖 AI 코드 리뷰 체크리스트

> PR 생성 전 Claude Code가 로컬에서 코드를 검토하고 체크합니다.
> Copilot, CodeRabbit 등 외부 AI 리뷰어는 리뷰 완료 후 코멘트로 결과를 요약합니다.

- [x] **보안 검토** — `/security-review` 실행, SQL Injection · XSS · 인증/인가 누락 · 민감 정보 노출 취약점 없음
- [x] **테스트 커버리지** — k6 부하 테스트 3종 + 결과 요약 포함