### PR TITLE
[Phase 1] Playwright E2E 설정 수정 및 Docker 환경 개선 (#7)

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/client/playwright.config.js
+++ b/client/playwright.config.js
@@ -14,11 +14,11 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests/e2e',
-  /* 테스트 타임아웃: 미구현 기능 대기 시간 최소화 */
-  timeout: 10000,
+  /* 테스트 타임아웃: Firefox 및 멀티 컨텍스트 시나리오 커버 */
+  timeout: 30000,
   /* 전역 expect 타임아웃 */
   expect: {
-    timeout: 5000,
+    timeout: 10000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -26,8 +26,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* CI에서는 재시도 없음: 미구현 테스트 실패 시 불필요한 시간 낭비 방지 */
   retries: 0,
-  /* CI에서 병렬 실행 */
-  workers: process.env.CI ? 2 : undefined,
+  /* 백엔드 과부하 방지: CI 2, 로컬 4 (기본값 CPU/2 사용 시 Firefox WebSocket 타임아웃 발생) */
+  workers: process.env.CI ? 2 : 4,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,7 +12,7 @@ COPY build.gradle .
 COPY settings.gradle .
 COPY gradle.properties .
 
-RUN chmod +x gradlew
+RUN chmod +x gradlew && sed -i 's/\r$//' gradlew
 
 # 의존성 다운로드 (소스 변경 시 재다운로드 방지)
 RUN ./gradlew dependencies --no-daemon 2>/dev/null || true


### PR DESCRIPTION
## 🔗 관련 이슈 / SPEC

- Closes #7
- 구현 SPEC: `SPEC-MSG-001~005`, `SPEC-READ-001`

---

## 📝 변경 사항 요약

### 추가
- 없음

### 수정
- `client/playwright.config.js`: 전역 timeout 10s→30s, expect timeout 5s→10s (멀티 컨텍스트/Firefox 커버)
- `client/playwright.config.js`: workers 기본값(CPU/2≈14)→4 (병렬 실행 시 백엔드 WebSocket 과부하 방지)
- `client/Dockerfile`: `node:18-alpine` → `node:20-alpine`
- `server/Dockerfile`: `gradlew` CRLF 제거(`sed -i 's/\r$//'`) 추가

### 삭제
- 없음

---

## ✅ 테스트 실행 결과

> PR 생성 전 로컬에서 모두 실행 후 결과를 기록합니다.

### Server 단위 테스트 (`./gradlew test`)
- [x] 해당 없음 — Server 코드 변경 없음

### Server 통합 테스트 (`./gradlew integrationTest`, MySQL)
- [x] 해당 없음 — Server 코드 변경 없음

### Client 단위 테스트 (`npm test`)
- [x] 해당 없음 — Client 비즈니스 로직 변경 없음

### E2E 테스트 (`cd client && npx playwright test`)
- [x] 통과
- 실행 결과: `96 passed, 0 failed` (chromium/firefox/webkit, 1.2min)
- 수정 전: 10 failed (멀티 컨텍스트 타임아웃 2건 + Firefox 과부하 8건)

---

## 🤖 AI 코드 리뷰 체크리스트

> PR 생성 전 Claude Code가 로컬에서 코드를 검토하고 체크합니다.
> Copilot, CodeRabbit 등 외부 AI 리뷰어는 리뷰 완료 후 코멘트로 결과를 요약합니다.

- [x] **인수 조건(AC) 충족** — E2E 32개 시나리오(로그인·방 생성·메시지·읽음·검색) AC 항목 전체 통과 확인